### PR TITLE
Bugfix: Fix incorrect check of write capability of the Defaults folder.

### DIFF
--- a/src/Yamoh/Infrastructure/EnvironmentUtility/AppEnvironment.cs
+++ b/src/Yamoh/Infrastructure/EnvironmentUtility/AppEnvironment.cs
@@ -9,7 +9,6 @@ public class AppEnvironment
     public string LogFolder { get; }
     public string StateFolder { get; }
     public bool IsDocker { get; }
-    public List<string> Folders => [ConfigFolder, DefaultsFolder, LogFolder, StateFolder];
 
     public AppEnvironment()
     {

--- a/src/Yamoh/Infrastructure/EnvironmentUtility/AppFolderInitializer.cs
+++ b/src/Yamoh/Infrastructure/EnvironmentUtility/AppFolderInitializer.cs
@@ -31,7 +31,7 @@ public class AppFolderInitializer(AppEnvironment env)
         try
         {
             // Test read
-            var files = Directory.GetFiles(path);
+            var files = Directory.EnumerateFiles(path).Take(1).Any();
 
             if (includeWrite)
             {

--- a/src/Yamoh/Program.cs
+++ b/src/Yamoh/Program.cs
@@ -44,7 +44,7 @@ initializer.Initialize();
 
 var folderPermissionErrors = initializer.CheckRequiredFolderPermissions();
 
-if (folderPermissionErrors.Count != 0)
+if (folderPermissionErrors.Any(x => !x.Successful))
 {
     foreach (var error in folderPermissionErrors)
     {


### PR DESCRIPTION
This PR fixes an incorrect permission check for the Defaults folder in a Docker environment where the app loses write permissions due to PUID/PGID overrides. The fix changes the permission checking logic to differentiate between read-only and read-write folders, with the Defaults folder now requiring only read permissions.

- Changed permission check logic from count-based to boolean success checking
- Refactored permission checking to explicitly control read vs read-write requirements per folder
- Updated the Defaults folder to only require read permissions instead of write permissions


In the future these checks and the creation of the defaults needs to be handled in the bootstrapper itself, but for now lets just ship it. 