### PR TITLE
Migrate to maintainerr collections api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ appsettings.*.json
 
 # compose files
 compose.yaml
+
+# Ignore local Claude Code overrides
+.claude/settings.local.json
+.claude/plans/
+CLAUDE.local.md

--- a/src/Yamoh/Domain/Maintainerr/IMaintainerrMediaResponse.cs
+++ b/src/Yamoh/Domain/Maintainerr/IMaintainerrMediaResponse.cs
@@ -6,7 +6,7 @@ public interface IMaintainerrMediaResponse
     public int CollectionId { get; }
     public string? MediaServerId { get; }
     public int TmdbId { get; }
-    public DateTime AddDate { get; }
+    public DateTimeOffset AddDate { get; }
     public string? ImagePath { get; }
     public bool IsManual { get; }
 }

--- a/src/Yamoh/Domain/Maintainerr/MaintainerrMediaResponseV2.cs
+++ b/src/Yamoh/Domain/Maintainerr/MaintainerrMediaResponseV2.cs
@@ -7,7 +7,7 @@ public class MaintainerrMediaResponseV2 : IMaintainerrMediaResponse
     public string? MediaServerId => PlexId.ToString();
     public int PlexId { get; set; }
     public int TmdbId { get; set; }
-    public DateTime AddDate { get; set; }
+    public DateTimeOffset AddDate { get; set; }
     public string? ImagePath { get; set; }
     public bool IsManual { get; set; }
 }

--- a/src/Yamoh/Domain/Maintainerr/MaintainerrMediaResponseV3.cs
+++ b/src/Yamoh/Domain/Maintainerr/MaintainerrMediaResponseV3.cs
@@ -6,7 +6,7 @@ public class MaintainerrMediaResponseV3 : IMaintainerrMediaResponse
     public int CollectionId { get; set; }
     public string? MediaServerId { get; set; }
     public int TmdbId { get; set; }
-    public DateTime AddDate { get; set; }
+    public DateTimeOffset AddDate { get; set; }
     public string? ImagePath { get; set; }
     public bool IsManual { get; set; }
 }

--- a/src/Yamoh/Features/OverlayManager/PlexMetadataBuilder.cs
+++ b/src/Yamoh/Features/OverlayManager/PlexMetadataBuilder.cs
@@ -333,7 +333,7 @@ public class PlexMetadataBuilder(
         int deleteAfterDays,
         List<MaintainerrMediaDto> maintainerrMedia,
         bool asChild,
-        Func<GetMediaMetaDataMediaContainer, string, DateTime, Task<IEnumerable<PlexMetadataBuilderItem>>> buildItems)
+        Func<GetMediaMetaDataMediaContainer, string, DateTimeOffset, Task<IEnumerable<PlexMetadataBuilderItem>>> buildItems)
     {
         if (asChild)
         {
@@ -377,9 +377,8 @@ public class PlexMetadataBuilder(
                 {
                     if (deleteAfterDays > 0)
                     {
-                        var addDate = new DateTimeOffset(maintainerrItem.AddDate);
                         builtItem.HasExpiration = true;
-                        builtItem.ExpirationDate = addDate.AddDays(deleteAfterDays);
+                        builtItem.ExpirationDate = maintainerrItem.AddDate.AddDays(deleteAfterDays);
                     }
 
                     builtItem.KometaLabelExists = await plexClient.HasKometaOverlay(plexId);
@@ -453,7 +452,7 @@ public class PlexMetadataBuilder(
         throw new InvalidOperationException("Plex Library metadata could not be retrieved");
     }
 
-    private record MaintainerrMediaDto(string PlexId, DateTime AddDate);
+    private record MaintainerrMediaDto(string PlexId, DateTimeOffset AddDate);
 
     private record PlexLibraryInfoDto(
         long LibrarySectionId,

--- a/src/Yamoh/Infrastructure/External/MaintainerrClient.cs
+++ b/src/Yamoh/Infrastructure/External/MaintainerrClient.cs
@@ -15,6 +15,7 @@ public class MaintainerrClient(
     private readonly YamohConfiguration _config = config.Value;
     private readonly HttpClient _httpClient = clientFactory.CreateClient("YAMOH");
     private static readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+    private static readonly Version _overlayDataMinVersion = new(3, 4, 0);
     private Version? _cachedVersion;
 
     public async Task<Version?> GetVersionAsync()
@@ -48,13 +49,19 @@ public class MaintainerrClient(
         {
             var version = await GetVersionAsync();
 
+            var baseUrl = this._config.MaintainerrUrl.TrimEnd('/');
+
             if (version?.Major >= 3)
             {
-                var overlayUrl = this._config.MaintainerrUrl.TrimEnd('/') + "/api/collections/overlay-data";
-                return await GetMaintainerrCollectionResponseListAsync<MaintainerrCollectionResponseV3>(overlayUrl);
+                var collectionsUrl = baseUrl + "/api/collections";
+                if (version >= _overlayDataMinVersion)
+                {
+                    return await GetMaintainerrCollectionResponseListAsync<MaintainerrCollectionResponseV3>(baseUrl + "/api/collections/overlay-data");
+                }
+                return await GetMaintainerrCollectionResponseListAsync<MaintainerrCollectionResponseV3>(collectionsUrl);
             }
-            var url = this._config.MaintainerrUrl.TrimEnd('/') + "/api/collections";
-            return await GetMaintainerrCollectionResponseListAsync<MaintainerrCollectionResponseV2>(url);
+
+            return await GetMaintainerrCollectionResponseListAsync<MaintainerrCollectionResponseV2>(baseUrl + "/api/collections");
         }
         catch (Exception ex)
         {

--- a/src/Yamoh/Infrastructure/External/MaintainerrClient.cs
+++ b/src/Yamoh/Infrastructure/External/MaintainerrClient.cs
@@ -46,12 +46,15 @@ public class MaintainerrClient(
     {
         try
         {
-            var url = this._config.MaintainerrUrl.TrimEnd('/') + "/api/collections";
             var version = await GetVersionAsync();
 
-            return version?.Major >= 3
-                ? await GetMaintainerrCollectionResponseListAsync<MaintainerrCollectionResponseV3>(url)
-                : await GetMaintainerrCollectionResponseListAsync<MaintainerrCollectionResponseV2>(url);
+            if (version?.Major >= 3)
+            {
+                var overlayUrl = this._config.MaintainerrUrl.TrimEnd('/') + "/api/collections/overlay-data";
+                return await GetMaintainerrCollectionResponseListAsync<MaintainerrCollectionResponseV3>(overlayUrl);
+            }
+            var url = this._config.MaintainerrUrl.TrimEnd('/') + "/api/collections";
+            return await GetMaintainerrCollectionResponseListAsync<MaintainerrCollectionResponseV2>(url);
         }
         catch (Exception ex)
         {

--- a/src/Yamoh/Yamoh.csproj
+++ b/src/Yamoh/Yamoh.csproj
@@ -12,25 +12,25 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0"/>
-        <PackageReference Include="CronExpressionDescriptor" Version="2.45.0" />
-        <PackageReference Include="Cronos" Version="0.11.1" />
-        <PackageReference Include="Humanizer" Version="3.0.8" />
+        <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
+        <PackageReference Include="CronExpressionDescriptor" Version="2.48.0" />
+        <PackageReference Include="Cronos" Version="0.13.0" />
+        <PackageReference Include="Humanizer" Version="3.0.10" />
         <PackageReference Include="LiteDB" Version="5.0.21" />
         <PackageReference Include="LukeHagar.PlexAPI.SDK" Version="0.16.1" />
-        <PackageReference Include="Magick.NET-Q16-x64" Version="14.10.3" />
-        <PackageReference Include="Magick.NET.SystemDrawing" Version="8.0.16" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
-        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.3" />
+        <PackageReference Include="Magick.NET-Q16-x64" Version="14.13.1" />
+        <PackageReference Include="Magick.NET.SystemDrawing" Version="8.0.22" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.8" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
-        <PackageReference Include="Serilog.Sinks.File" Version="7.0.0"/>
-        <PackageReference Include="Serilog.Sinks.Spectre" Version="0.5.0" />
-        <PackageReference Include="Spectre.Console" Version="0.54.0" />
-        <PackageReference Include="System.CommandLine" Version="2.0.3" />
-        <PackageReference Include="vertical-spectreconsolelogger" Version="0.10.1-dev.20241201.35"/>
+        <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+        <PackageReference Include="Serilog.Sinks.Spectre" Version="0.6.0" />
+        <PackageReference Include="Spectre.Console" Version="0.55.2" />
+        <PackageReference Include="System.CommandLine" Version="2.0.8" />
+        <PackageReference Include="vertical-spectreconsolelogger" Version="0.10.1-dev.20241201.35" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
  Fix Maintainerr API compatibility (v3.4+)

  Changes

  Fix addDate deserialization crash

  The Maintainerr API now returns addDate as an ISO 8601 string with a timezone offset (e.g. 2024-01-15T10:30:00.000+00:00).
  System.DateTime does not support timezone-offset strings during JSON deserialization, causing a hard crash when fetching
  collections. Changed AddDate to DateTimeOffset throughout (IMaintainerrMediaResponse, both V2/V3 response models,
  MaintainerrMediaDto, and the buildItems delegate in PlexMetadataBuilder). Removed the now-redundant new DateTimeOffset(...)
   wrapper that was already wrapping the value downstream.

  Switch to /api/collections/overlay-data for v3+

  Maintainerr v3.4.0 introduced a dedicated GET /api/collections/overlay-data endpoint for overlay integrations. The existing
   GET /api/collections endpoint was changed at the same time to return only 2 preview media items per collection (for UI
  display), meaning Yamoh was silently applying overlays to at most 2 items per collection. The new endpoint returns the full
   media membership and is explicitly documented as being for overlay consumers. Yamoh now uses /api/collections/overlay-data
   for Maintainerr v3+ and continues to use /api/collections for v2.

  Tested against

  - Maintainerr v3.4+ (both fixes apply)
  - v2 path unchanged